### PR TITLE
Add another warning to install the core plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 Workspaces Plus is a plugin that expands the functionality of [workspaces](https://help.obsidian.md/Plugins/Workspaces) in [Obsidian](https://obsidian.md/). 
 
+> **Warning**
+> Obsidian's core workspace plugin must be activated for Workspaces Plus to work properly
+
 ## Features
 **Workspace Indicator**
 - current active workspace shown in status bar
@@ -37,8 +40,8 @@ Workspaces Plus is a plugin that expands the functionality of [workspaces](https
 ## How to use
 After enabling the plugin from the settings menu, you will see that a workspace icon has been added to the status bar in the lower right corner of the interface. If you are already using workspaces in Obsidian, you will notice that the name of your current active workspace is located next to the that icon.
 
-> :warning: **Obsidian's core workspace plugin must be activated for Workspaces Plus to work properly**
-
+> **Warning**
+> Obsidian's core workspace plugin must be activated for Workspaces Plus to work properly
 
 ### Creating a Workspace
 You can create a workspace through either the Workspace Picker or the Workspace Switcher modal with the same workflow


### PR DESCRIPTION
Since the current warning is very far down the page (past a bunch of screenshots) it is very easy to miss.

Note: I'm not sure how Obsidian's community plugin browser will render the GFM style admonition

On GitHub the admonition shows up as:
![Screen Shot 2022-08-21 07-31-05](https://user-images.githubusercontent.com/9973/185803588-180b4ecf-34ad-4c61-b3cd-e6bfc7d86b9f.png)

It is viewable at https://github.com/nothingislost/obsidian-workspaces-plus/blob/e0b8e1dafd3e9e0d07b98092571e8aedb3e32b3a/README.md

Related: https://github.com/nothingislost/obsidian-workspaces-plus/issues/81