### PR TITLE
fix: enable tabs to be parse in the workspace plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,62 +2,91 @@
 
 ![Artboard-2-3](https://user-images.githubusercontent.com/46250921/133352216-e0a2c9b6-070b-46f7-9a6f-d3a18f0c69b1.png)
 
-Workspaces Plus is a plugin that expands the functionality of [workspaces](https://help.obsidian.md/Plugins/Workspaces) in [Obsidian](https://obsidian.md/). 
+Workspaces Plus is a plugin that expands the functionality of [workspaces](https://help.obsidian.md/Plugins/Workspaces) in [Obsidian](https://obsidian.md/).
 
 ## Features
-**Workspace Indicator**
+
+### Workspace Indicator
+
 - current active workspace shown in status bar
-- click on workspace name in status bar to open workspace picker menu 
+- click on workspace name in status bar to open workspace picker menu
 - `shift-click` status bar icon or workspace name to save the workspace
 <img src="https://user-images.githubusercontent.com/46250921/133325073-af2d58ec-e8a1-48fb-a48c-792b348235fd.png" width="350">
 
-**Workspace Picker**
+### Workspace Picker
+
 - switch, delete, rename, and create new workspaces
 <img src="https://user-images.githubusercontent.com/46250921/133325287-94a36543-f0ee-4956-9ad5-91c572e5b3c4.png" width="350">
 
-**Workspace Switcher modal**
+### Workspace Switcher modal
+
 - open with assignable hotkey
 - switch, delete, rename, and create new workspaces
 <img src="https://user-images.githubusercontent.com/46250921/133325396-bc429aa5-696f-4e44-8e78-4a9bd504867e.png" width="400">
 
-**Hotkeys**
+### Hotkeys
+
 - open Workspaces Plus switcher modal
 - open specific workspace by name
 
-**Plugin Options**
+### Plugin Options
+
 - Toggle keyboard shortcuts on/off for Workspace Picker
 - Toggle workspace delete confirmation on/off
 - Set default workspace switch behavior to always save when switching
 
-**Theming Options**
+### Theming Options
+
 - Workspaces Plus adds a data attribute to the HTML document body which can be used to set workspace specific styling
   - The data attribute is body[data-workspace-name="My Workspace"]
   - The attribute will be updated upon the loading of any new workspace
 
+### Workspace Overrides
+
+- Ability to override pages in a workspace using the templates variables.
+
 ## How to use
+
 After enabling the plugin from the settings menu, you will see that a workspace icon has been added to the status bar in the lower right corner of the interface. If you are already using workspaces in Obsidian, you will notice that the name of your current active workspace is located next to the that icon.
 
 > :warning: **Obsidian's core workspace plugin must be activated for Workspaces Plus to work properly**
 
-
 ### Creating a Workspace
+
 You can create a workspace through either the Workspace Picker or the Workspace Switcher modal with the same workflow
+
 1. Type your new workspace name into the input field
 2. Use `shift-enter` to create the new workspace
+
 ### Renaming a Workspace
+
 Rename workspaces from the picker or modal by clicking on the pencil icon next to the workspace name
+
 ### Deleting a Workspace
+
 Workspaces can be deleted by either using the trach can icon next to the workspaces name or pressing the shortcut `shift-delete` while the workspace is selected in the menu
+
 ### Opening a Workspace
+
 1. Open the Workspace Switcher via hotkey or click on the workspace icon or name in status bar to open the Workspace Picker
 2. You can open a workspace by clicking on it with your mouse or by pressing enter after navigating to it with the up/down arrows on your keyboard
+
 ### Saving Workspaces
+
 - By default, workspaces are not automatically saved when switched
 - You can save a workspace with `shift-click` on the workspace icon or name in the status bar
 - From either switcher menu you can use `shift-enter` to save your current active workspace or `alt-enter` to save your current active workspace and switch to the new one you have selected
 - In the Plugin Options menu (located in Obsidians settings) you can toggle on a setting which will automatically save the active workspace on switch
 
+### Overriding a page in a Workspace
+
+- In settings scroll to the bottom and open the workspace you want to modify.
+- In the text box next to the page ID enter the string to load with template variables
+  - Example: 1 Journal/{{date:YYYY}}/{{date:YYYY-MM}}/{{date:YYYY-MM-DD}}.md
+- Switch to the workspace and the page will be loaded with the value from the override with the variables replaced.
+
 ## Extra
+
 <details>
   <summary>Compact Workspace Picker CSS Snippet</summary>
   
@@ -116,6 +145,7 @@ Workspaces can be deleted by either using the trach can icon next to the workspa
   right: 2em !important;
 }
 ```
+
 </details>
 
 ## Installation
@@ -124,13 +154,19 @@ Workspaces can be deleted by either using the trach can icon next to the workspa
 - via Obsidian Community Plugins browser
 
 ## Feedback
+
 Share feedback, issues, and ideas on [github](https://github.com/nothingislost/obsidian-workspaces-plus/issues), with our [Workspaces Plus feedback survey](https://airtable.com/shrETC7GS1MOYSTAI), or tag the authors on Discord!
 
 ## Credits
+
 - This plugin is being developed by [Johnny ✨](https://github.com/jsmorabito) and [Nothingislost](https://github.com/nothingislost)
 - Workspace Picker and Modal based off of [Obsidian Theme Picker](https://github.com/kenset/obsidian-theme-picker) by [Kenset](https://github.com/kenset)
 
 ## Changelog
+
+- 0.4.17 - Beta
+  - Fix issue with workspaces using tabs so they are parsed correctly for overrides.
+  - Added details on how to use overrides to template files and paths.
 
 - 0.3.1
   - Fix bug in workspace rename logic which was preventing hotkey reassignment

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,8 +1,8 @@
 {
   "id": "workspaces-plus",
   "name": "Workspaces Plus",
-  "version": "0.4.16",
-  "minAppVersion": "0.9.12",
+  "version": "0.4.17",
+  "minAppVersion": "1.1.1",
   "description": "Quickly switch and manage workspaces",
   "author": "NothingIsLost",
   "authorUrl": "https://github.com/nothingislost",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^14.14.37",
     "auto": "^10.31.0",
     "auto-plugin-obsidian": "^0.1.4",
-    "obsidian": "^0.12.0",
+    "obsidian": "^1.1.1",
     "rollup": "^2.32.1",
     "rollup-plugin-copy-watch": "^0.0.1",
     "tslib": "^2.2.0",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -35,12 +35,10 @@ export const DEFAULT_SETTINGS: WorkspacesPlusSettings = {
   replaceNativeRibbon: false,
 };
 
-function getChildIds(split: any, leafs: any[] = null): any {
-  // recursive function to get metadata from all leafs in a workspace split
-  if (!leafs) leafs = [];
-  if (split.type == "leaf") {
+function getChildIds (split: any, leafs: any[] = []): any[] {
+  if (split.type === "leaf") {
     leafs.push({ id: split.id, file: split.state.state.file, mode: split.state.state.mode });
-  } else if (split.type == "split") {
+  } else if (split.type === "split" || split.type === "tabs") {
     split.children.forEach((child: any) => {
       getChildIds(child, leafs);
     });
@@ -51,12 +49,12 @@ function getChildIds(split: any, leafs: any[] = null): any {
 export class WorkspacesPlusSettingsTab extends PluginSettingTab {
   plugin: WorkspacesPlus;
 
-  constructor(app: App, plugin: WorkspacesPlus) {
+  constructor (app: App, plugin: WorkspacesPlus) {
     super(app, plugin);
     this.plugin = plugin;
   }
 
-  display(): void {
+  display (): void {
     const { containerEl } = this;
     containerEl.empty();
 


### PR DESCRIPTION
It was failing in the newer versions of Obsidian as tabs are part of the child types now, this updates the logic so it works and the replacements can happen when switching workspaces.