### PR TITLE
Add commands to cycle workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Workspaces Plus is a plugin that expands the functionality of [workspaces](https
 
 - open Workspaces Plus switcher modal
 - open specific workspace by name
+- cycle to the next workspace
+- save the current workspace and cycle to the next workspace
 
 ### Plugin Options
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "rollup --config rollup.config.js -w",
     "build": "rollup --config rollup.config.js --environment BUILD:production",
+    "test": "node tests/workspaceCycle.test.js",
     "release": "auto shipit"
   },
   "keywords": [],

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import { WorkspacesPlusPluginWorkspaceModal } from "./workspaceModal";
 import { WorkspacesPlusPluginModeModal } from "./modeModal";
 import { around } from "monkey-around";
 import Utils from "./utils";
+import { cycleWorkspace as runWorkspaceCycle } from "./workspaceCycle";
 
 export default class WorkspacesPlus extends Plugin {
   settings: WorkspacesPlusSettings;
@@ -129,6 +130,26 @@ export default class WorkspacesPlus extends Plugin {
         new Notice("Successfully saved workspace: " + this.workspacePlugin.activeWorkspace);
       },
     });
+    this.addCommand({
+      id: "cycle-workspace",
+      name: "Cycle to next workspace",
+      callback: () => this.cycleWorkspace(),
+    });
+    this.addCommand({
+      id: "save-and-cycle-workspace",
+      name: "Save current workspace and cycle to next",
+      callback: () => this.cycleWorkspace(true),
+    });
+  }
+
+  cycleWorkspace(saveCurrent: boolean = false): void {
+    const activeWorkspace = this.workspacePlugin.activeWorkspace;
+    runWorkspaceCycle(
+      Object.keys(this.workspacePlugin.workspaces),
+      activeWorkspace,
+      workspaceName => this.workspacePlugin.loadWorkspace(workspaceName),
+      saveCurrent ? workspaceName => this.workspacePlugin.saveWorkspace(workspaceName) : undefined
+    );
   }
 
   registerEventHandlers() {

--- a/src/workspaceCycle.ts
+++ b/src/workspaceCycle.ts
@@ -1,0 +1,15 @@
+export function cycleWorkspace(
+  workspaceNames: string[],
+  activeWorkspace: string,
+  loadWorkspace: (name: string) => void,
+  saveWorkspace?: (name: string) => void
+): void {
+  const workspaces = workspaceNames.filter(name => !/^mode:/i.test(name)).sort();
+  if (workspaces.length === 0) return;
+
+  if (saveWorkspace && activeWorkspace) saveWorkspace(activeWorkspace);
+
+  const activeIndex = workspaces.indexOf(activeWorkspace);
+  const nextWorkspace = workspaces[(activeIndex + 1) % workspaces.length];
+  if (nextWorkspace !== activeWorkspace) loadWorkspace(nextWorkspace);
+}

--- a/tests/workspaceCycle.test.js
+++ b/tests/workspaceCycle.test.js
@@ -1,0 +1,31 @@
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+
+const source = fs.readFileSync(path.join(__dirname, "../src/workspaceCycle.ts"), "utf8");
+const output = ts.transpileModule(source, {
+  compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES6 },
+}).outputText;
+const compiled = { exports: {} };
+new Function("require", "module", "exports", output)(require, compiled, compiled.exports);
+const { cycleWorkspace } = compiled.exports;
+
+const calls = [];
+const load = name => calls.push(`load:${name}`);
+const save = name => calls.push(`save:${name}`);
+
+cycleWorkspace(["Work", "mode: Focus", "Home"], "Home", load);
+assert.deepStrictEqual(calls.splice(0), ["load:Work"]);
+
+cycleWorkspace(["Work", "Home"], "Work", load);
+assert.deepStrictEqual(calls.splice(0), ["load:Home"]);
+
+cycleWorkspace(["Work", "Home"], "Home", load, save);
+assert.deepStrictEqual(calls.splice(0), ["save:Home", "load:Work"]);
+
+cycleWorkspace(["Home"], "Home", load, save);
+assert.deepStrictEqual(calls.splice(0), ["save:Home"]);
+
+cycleWorkspace([], "", load, save);
+assert.deepStrictEqual(calls, []);


### PR DESCRIPTION
## Summary

- add an assignable command to cycle to the next workspace
- add an assignable command to save the current workspace before cycling
- cycle alphabetically and exclude workspace modes

## Testing

- `npm test`
- production bundle generated and verified to contain both commands