### PR TITLE
Surface core-workspace-plugin warning near the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 Workspaces Plus is a plugin that expands the functionality of [workspaces](https://help.obsidian.md/Plugins/Workspaces) in [Obsidian](https://obsidian.md/).
 
+> [!WARNING]
+> Obsidian's core workspace plugin must be activated for Workspaces Plus to work properly
+
 ## Features
 
 ### Workspace Indicator
@@ -51,7 +54,8 @@ Workspaces Plus is a plugin that expands the functionality of [workspaces](https
 
 After enabling the plugin from the settings menu, you will see that a workspace icon has been added to the status bar in the lower right corner of the interface. If you are already using workspaces in Obsidian, you will notice that the name of your current active workspace is located next to the that icon.
 
-> :warning: **Obsidian's core workspace plugin must be activated for Workspaces Plus to work properly**
+> [!WARNING]
+> Obsidian's core workspace plugin must be activated for Workspaces Plus to work properly
 
 ### Creating a Workspace
 


### PR DESCRIPTION
## Summary
Carries forward the intent of #82 (@axelson) — the warning that Obsidian's core Workspaces plugin must be enabled was buried past a long run of feature screenshots and easy to miss. #82's branch predates a lot of README restructuring since 2022 and no longer applies cleanly (GitHub reports it CONFLICTING), so this reapplies the same idea directly against current `master`:

- Adds the warning right after the intro, before the screenshot-heavy Features section
- Updates both occurrences from the old `:warning:` emoji-shortcode style to GitHub's current `[!WARNING]` alert syntax

Fixes #82

## Test plan
- [x] Rendered README.md to confirm both admonitions render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)