### PR TITLE
Add declarative settings API (Obsidian 1.13.0+), fix two workspace-load bugs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,5 +27,16 @@ export default defineConfig(
       },
     },
   },
-  ...obsidianmd.configs.recommended
+  ...obsidianmd.configs.recommended,
+  {
+    // settings.ts intentionally implements getSettingDefinitions/getControlValue/setControlValue/
+    // update() (Obsidian 1.13.0+) alongside display() as a fallback for 1.8.7-1.12.x. Obsidian itself
+    // only calls the newer methods when getSettingDefinitions() is in play, i.e. only on 1.13.0+, so
+    // no-unsupported-api's warning doesn't apply here -- this file is a deliberate two-tier
+    // implementation, not an accidental version mismatch.
+    files: ["src/settings.ts"],
+    rules: {
+      "obsidianmd/no-unsupported-api": "off",
+    },
+  }
 );

--- a/src/main.ts
+++ b/src/main.ts
@@ -163,12 +163,17 @@ export default class WorkspacesPlus extends Plugin {
 
   setPlatformWorkspace(): void {
     if (!this.isNativePluginEnabled) return;
-    // note: don't call this too early in the init process or setActiveWorkspace will wipe all workspaces
+    // note: don't call this too early in the init process or loadWorkspace will wipe all workspaces
     const _activeWorkspace = this.app.isMobile
       ? this.settings.activeWorkspaceMobile
       : this.settings.activeWorkspaceDesktop;
     if (_activeWorkspace) {
-      this.workspacePlugin.setActiveWorkspace(_activeWorkspace);
+      // loadWorkspace (not setActiveWorkspace) so the saved layout is actually reapplied on
+      // startup, not just the active-workspace label. Obsidian's own setActiveWorkspace only sets
+      // that label; without an actual reload, the status bar can end up naming a workspace whose
+      // layout was never restored, disagreeing with whatever Obsidian's native session-restore
+      // happened to reopen.
+      this.workspacePlugin.loadWorkspace(_activeWorkspace);
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -565,14 +565,23 @@ export default class WorkspacesPlus extends Plugin {
               if (workspace) {
                 this.activeWorkspace = workspaceName;
                 // Restore tracked files along with overrides
-                const restore = plugin.settings.trackOpenFiles
-                  ? plugin.utils
-                      .restoreOpenFiles(workspaceName, workspace)
-                      .then(() => plugin.utils.applyFileOverrides(workspaceName, workspace))
+                const restore: Promise<string[]> = plugin.settings.trackOpenFiles
+                  ? plugin.utils.restoreOpenFiles(workspaceName, workspace).then(async restoredLeafIds => {
+                      const overriddenLeafIds = await plugin.utils.applyFileOverrides(workspaceName, workspace);
+                      return [...restoredLeafIds, ...overriddenLeafIds];
+                    })
                   : plugin.utils.applyFileOverrides(workspaceName, workspace);
                 restore
-                  .then(() => {
-                    void this.app.workspace.changeLayout(workspace);
+                  .then(async loadedLeafIds => {
+                    await this.app.workspace.changeLayout(workspace);
+                    // changeLayout() creates the leaves but leaves in the background stay
+                    // "deferred" (a lightweight placeholder) until focused -- force-load the
+                    // ones we just set a file on so they render immediately instead of only
+                    // on click.
+                    for (const leafId of loadedLeafIds) {
+                      const leaf = this.app.workspace.getLeafById(leafId);
+                      if (leaf?.isDeferred) await leaf.loadIfDeferred();
+                    }
                     this.saveData();
                   })
                   .catch((e: unknown) => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,15 @@
 import WorkspacesPlus from "./main";
-import { App, PluginSettingTab, Setting, setIcon, WorkspaceLayoutNode } from "obsidian";
+import {
+  App,
+  PluginSettingTab,
+  Setting,
+  setIcon,
+  WorkspaceLayoutNode,
+  Workspaces,
+  SettingDefinitionItem,
+  SettingGroupItem,
+  SettingDefinitionPage,
+} from "obsidian";
 import { FileSuggest } from "./suggesters/fileSuggest";
 
 export class WorkspacesPlusSettings {
@@ -334,6 +344,208 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
           })
         );
     });
+  }
+
+  // Declarative settings API (Obsidian 1.13.0+). display() above remains the
+  // fallback for older versions (minAppVersion is 1.8.7) -- Obsidian only
+  // calls display() when this returns an empty array, which is what the
+  // inherited default does on versions that predate this API entirely.
+  // Keep the two in sync when editing either: same settings, same text,
+  // necessarily different structure (imperative DOM vs. declarative tree).
+  getSettingDefinitions(): SettingDefinitionItem[] {
+    if (!this.plugin.utils.isNativePluginEnabled) {
+      return [{ name: "Please enable the workspaces plugin under core plugins before using this plugin" }];
+    }
+
+    const { workspaces } = this.plugin.workspacePlugin;
+    const workspacePages: SettingGroupItem[] = Object.keys(workspaces)
+      .filter(name => !this.plugin.utils.isMode(name))
+      .map(name => this.buildWorkspacePage(name, workspaces[name]));
+    const modePages: SettingGroupItem[] = Object.keys(workspaces)
+      .filter(name => this.plugin.utils.isMode(name))
+      .map(name => this.buildModePage(name));
+
+    return [
+      {
+        type: "group",
+        heading: "Quick switcher",
+        items: [
+          {
+            name: "Show instructions",
+            desc: "Show available keyboard shortcuts at the bottom of the workspace quick switcher",
+            control: { type: "toggle", key: "showInstructions" },
+          },
+          {
+            name: "Show workspace delete confirmation",
+            desc: "Show a confirmation prompt on workspace deletion",
+            control: { type: "toggle", key: "showDeletePrompt" },
+          },
+          {
+            name: "Show workspace sidebar ribbon icon",
+            control: { type: "toggle", key: "workspaceSwitcherRibbon" },
+          },
+          {
+            name: "Hide the native workspace sidebar ribbon icon",
+            control: { type: "toggle", key: "replaceNativeRibbon" },
+          },
+          {
+            name: "Show workspace mode sidebar ribbon icon",
+            control: { type: "toggle", key: "modeSwitcherRibbon" },
+          },
+        ],
+      },
+      {
+        type: "group",
+        heading: "Workspace enhancements",
+        items: [
+          {
+            name: "Workspace modes (beta)",
+            desc: "Modes are a new type of workspace that store all of the native Obsidian editor, files & links, and appearance settings. Enabling this will add a new mode switcher to the status bar that will allow you to save, apply, rename, and switch between modes.",
+            control: { type: "toggle", key: "workspaceSettings" },
+          },
+          {
+            name: "Auto save the current workspace on layout change",
+            desc: "This option will auto save your current workspace on any layout change. Leave this disabled if you want full control over when your workspace is saved.",
+            control: { type: "toggle", key: "saveOnChange" },
+          },
+          {
+            name: "Automatically track and restore open files",
+            desc: "When enabled, workspaces will remember which files were open and restore them when you switch back. This preserves your exact layout and open notes across workspace switches.",
+            control: { type: "toggle", key: "trackOpenFiles" },
+          },
+          {
+            name: "Respect system dark mode setting",
+            desc: "Let the os determine the light/dark mode setting when switching modes. This setting can only be used if workspace modes is enabled.",
+            control: { type: "toggle", key: "systemDarkMode" },
+            visible: () => this.plugin.settings.workspaceSettings,
+          },
+          {
+            name: "Automatically reload Obsidian on live preview setting change",
+            desc: "When switching between modes with different experimental live preview settings, reload Obsidian in order for the setting change to take effect. ⚠️note: Obsidian will reload automatically after changing workspaces, if needed, without any prompts.",
+            control: { type: "toggle", key: "reloadLivePreview" },
+            visible: () => this.plugin.settings.workspaceSettings,
+          },
+        ],
+      },
+      { type: "group", heading: "Per workspace", items: workspacePages },
+      {
+        type: "group",
+        heading: "Per mode",
+        items: modePages,
+        visible: () => this.plugin.settings.workspaceSettings,
+      },
+    ];
+  }
+
+  private buildWorkspacePage(workspaceName: string, workspace: Workspaces): SettingDefinitionPage {
+    const overrides: SettingGroupItem[] = getChildIds(workspace.main).map(leaf => ({
+      name: leaf.id ?? "unknown",
+      control: {
+        type: "file",
+        key: `workspace-override:${encodeURIComponent(workspaceName)}:${encodeURIComponent(leaf.id ?? "")}`,
+        placeholder: leaf.file ?? "",
+      },
+    }));
+
+    return {
+      type: "page",
+      name: workspaceName,
+      items: [
+        {
+          name: "Workspace description",
+          control: { type: "text", key: `workspace-description:${encodeURIComponent(workspaceName)}` },
+        },
+        { type: "group", heading: "File overrides", items: overrides },
+      ],
+    };
+  }
+
+  private buildModePage(modeName: string): SettingDefinitionPage {
+    return {
+      type: "page",
+      name: modeName.replace(/^mode: /i, ""),
+      items: [
+        {
+          name: "Save and load left/right sidebar state",
+          control: { type: "toggle", key: `mode-save-sidebar:${encodeURIComponent(modeName)}` },
+        },
+      ],
+    };
+  }
+
+  getControlValue(key: string): unknown {
+    if (key.startsWith("workspace-description:")) {
+      const workspaceName = decodeURIComponent(key.slice("workspace-description:".length));
+      return this.plugin.utils.getWorkspaceSettings(workspaceName)?.description ?? "";
+    }
+    if (key.startsWith("workspace-override:")) {
+      const { workspaceName, leafId } = this.parseOverrideKey(key);
+      return this.plugin.utils.getWorkspaceSettings(workspaceName)?.fileOverrides?.[leafId] ?? "";
+    }
+    if (key.startsWith("mode-save-sidebar:")) {
+      const modeName = decodeURIComponent(key.slice("mode-save-sidebar:".length));
+      return this.plugin.utils.getModeSettings(modeName)?.saveSidebar ?? false;
+    }
+    // invoked by Obsidian itself when getSettingDefinitions() is in play, i.e. on 1.13.0+; display() is the fallback
+    // for 1.8.7-1.12.x, where these methods are simply never called. See the comment above getSettingDefinitions().
+    return super.getControlValue(key);
+  }
+
+  setControlValue(key: string, value: unknown): void {
+    if (key.startsWith("workspace-description:")) {
+      const workspaceName = decodeURIComponent(key.slice("workspace-description:".length));
+      const settings = this.plugin.utils.getWorkspaceSettings(workspaceName);
+      if (settings) settings.description = value as string;
+      this.plugin.workspacePlugin.saveData();
+      return;
+    }
+    if (key.startsWith("workspace-override:")) {
+      const { workspaceName, leafId } = this.parseOverrideKey(key);
+      const settings = this.plugin.utils.getWorkspaceSettings(workspaceName);
+      if (settings) {
+        if (!settings.fileOverrides) settings.fileOverrides = {};
+        const overrideFile = value as string;
+        if (overrideFile) settings.fileOverrides[leafId] = overrideFile;
+        else delete settings.fileOverrides[leafId];
+      }
+      this.plugin.workspacePlugin.saveData();
+      return;
+    }
+    if (key.startsWith("mode-save-sidebar:")) {
+      const modeName = decodeURIComponent(key.slice("mode-save-sidebar:".length));
+      const settings = this.plugin.utils.getModeSettings(modeName);
+      if (settings) settings.saveSidebar = value as boolean;
+      this.plugin.workspacePlugin.saveData();
+      return;
+    }
+
+    void super.setControlValue(key, value);
+
+    switch (key) {
+      case "workspaceSwitcherRibbon":
+        this.plugin.toggleWorkspaceRibbonButton();
+        break;
+      case "replaceNativeRibbon":
+        this.plugin.toggleNativeWorkspaceRibbon();
+        break;
+      case "modeSwitcherRibbon":
+        this.plugin.toggleModeRibbonButton();
+        break;
+      case "workspaceSettings":
+        if (value) this.plugin.enableModesFeature();
+        else this.plugin.disableModesFeature();
+        this.update();
+        break;
+    }
+  }
+
+  private parseOverrideKey(key: string): { workspaceName: string; leafId: string } {
+    const rest = key.slice("workspace-override:".length);
+    const sepIndex = rest.indexOf(":");
+    return {
+      workspaceName: decodeURIComponent(rest.slice(0, sepIndex)),
+      leafId: decodeURIComponent(rest.slice(sepIndex + 1)),
+    };
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -188,9 +188,13 @@ export default class Utils {
     return result.find(filePath => filePath);
   }
 
-  async applyFileOverrides (workspaceName: string, workspace: Workspaces): Promise<void> {
+  // Returns the leaf IDs that got a real file applied, so the caller can force-load them past
+  // Obsidian's deferred-view optimization after changeLayout() -- otherwise a background leaf's
+  // overridden file doesn't actually render until the user clicks that tab.
+  async applyFileOverrides (workspaceName: string, workspace: Workspaces): Promise<string[]> {
     const workspaceSettings = this.getWorkspaceSettings(workspaceName);
     const fileOverrides = workspaceSettings?.fileOverrides;
+    const appliedLeafIds: string[] = [];
     if (fileOverrides) {
       await Promise.all(
         Object.entries(fileOverrides).map(async ([leafId, fileName]: [string, string]) => {
@@ -206,10 +210,13 @@ export default class Utils {
           if (!result) {
             // clean up any overrides for panes that no longer exist
             delete fileOverrides[leafId];
+          } else if (file) {
+            appliedLeafIds.push(leafId);
           }
         })
       );
     }
+    return appliedLeafIds;
   }
 
   captureOpenFiles(workspace: Workspaces): { [key: string]: string } {
@@ -235,23 +242,27 @@ export default class Utils {
     return openFiles;
   }
 
-  async restoreOpenFiles(workspaceName: string, workspace: Workspaces): Promise<void> {
+  // Returns the leaf IDs that got a real file restored -- see the comment on applyFileOverrides.
+  async restoreOpenFiles(workspaceName: string, workspace: Workspaces): Promise<string[]> {
     const workspaceSettings = this.getWorkspaceSettings(workspaceName);
     const trackedFiles = workspaceSettings?.trackedFiles;
 
-    if (!trackedFiles) return;
+    if (!trackedFiles) return [];
 
+    const restoredLeafIds: string[] = [];
     for (const [leafId, filePath] of Object.entries(trackedFiles)) {
       const abstractFile = this.app.vault.getAbstractFileByPath(normalizePath(filePath));
       const file = abstractFile instanceof TFile ? abstractFile : null;
       if (file) {
         // FIle is found, set it
         this.setChildId(workspace.main, leafId, file.path);
+        restoredLeafIds.push(leafId);
       } else {
         // File not found, is not found, create a new one to keep layout intact
         this.setChildId(workspace.main, leafId, null);
       }
     }
+    return restoredLeafIds;
   }
 
   getModeSettings (name: string) {


### PR DESCRIPTION
## Summary
- Implements `getSettingDefinitions()`/`getControlValue()`/`setControlValue()` alongside the existing `display()`, which remains the fallback for Obsidian 1.8.7–1.12.x (`minAppVersion`). Obsidian only calls `display()` when `getSettingDefinitions()` returns empty, so this is additive, not a replacement.
  - Per-workspace and per-mode sections are now navigable `SettingDefinitionPage`s instead of in-place collapsible divs.
  - The file-overrides list's custom `FileSuggest` search box is replaced by the native `file` control type.
  - Conditionally-visible settings (dark mode / live-preview reload / the "Per mode" group) use the native `visible` predicate instead of the old CSS sibling-selector hack.
  - Live-tested on Obsidian 1.13.0+.
- Two real bugs found and fixed while testing the above:
  - **File overrides / tracked files didn't show until the tab was clicked.** `changeLayout()` creates panes, but background leaves stay in Obsidian's "deferred" placeholder state until focused. Now force-loads (`loadIfDeferred()`) exactly the leaves that had a file applied.
  - **Status bar could disagree with the actually-open workspace after a full restart.** Root-caused by extracting and reading Obsidian 1.13.7's actual `app.js`: `setActiveWorkspace()` only sets a label (`this.activeWorkspace = e; this.saveData()`), it never calls `changeLayout()`. Startup now calls `loadWorkspace()` instead, which actually reapplies the saved layout. Confirmed with the user this is the intended behavior (every launch now reapplies the last-used workspace's layout, rather than leaving Obsidian's native session-restore in place).

## Test plan
- [x] `npm run build`, `npm run lint` (0 errors), `npm test` all pass
- [x] Live-tested in Obsidian 1.13.0+: declarative settings tab renders correctly, all toggles/side-effects work, per-workspace/per-mode pages work, file-override control persists
- [x] File override now shows immediately on workspace switch, no click needed
- [x] Full app restart: status bar and open panes agree on the active workspace