### PR TITLE
Fix code-review findings from the declarative settings API PR

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,12 +29,14 @@ export default defineConfig(
   },
   ...obsidianmd.configs.recommended,
   {
-    // settings.ts intentionally implements getSettingDefinitions/getControlValue/setControlValue/
-    // update() (Obsidian 1.13.0+) alongside display() as a fallback for 1.8.7-1.12.x. Obsidian itself
-    // only calls the newer methods when getSettingDefinitions() is in play, i.e. only on 1.13.0+, so
-    // no-unsupported-api's warning doesn't apply here -- this file is a deliberate two-tier
-    // implementation, not an accidental version mismatch.
-    files: ["src/settings.ts"],
+    // settingsDeclarative.ts implements getSettingDefinitions/getControlValue/setControlValue
+    // (Obsidian 1.13.0+), used by WorkspacesPlusSettingsTab alongside display() in settings.ts
+    // as a fallback for 1.8.7-1.12.x. Obsidian itself only calls the newer methods when
+    // getSettingDefinitions() is in play, i.e. only on 1.13.0+, so no-unsupported-api's warning
+    // doesn't apply here -- this file is a deliberate two-tier implementation, not an
+    // accidental version mismatch. Scoped to just this file (not all of settings.ts) so the
+    // check stays active for display() and the rest of the settings tab.
+    files: ["src/settingsDeclarative.ts"],
     rules: {
       "obsidianmd/no-unsupported-api": "off",
     },

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,12 @@
-import { Plugin, WorkspacePluginInstance, setIcon, Notice, debounce, WorkspaceCustomSettings } from "obsidian";
+import {
+  Plugin,
+  WorkspacePluginInstance,
+  setIcon,
+  Notice,
+  debounce,
+  WorkspaceCustomSettings,
+  WorkspaceLeaf,
+} from "obsidian";
 import { WorkspacesPlusSettings, WorkspacesPlusSettingsTab, DEFAULT_SETTINGS } from "./settings";
 import { WorkspacesPlusPluginWorkspaceModal } from "./workspaceModal";
 import { WorkspacesPlusPluginModeModal } from "./modeModal";
@@ -593,36 +601,41 @@ export default class WorkspacesPlus extends Plugin {
                 // Guards against a rapid second switch superseding this one while its restore
                 // chain is still in flight (see the generation checks below).
                 const generation = ++plugin.workspaceLoadGeneration;
-                // Restore tracked files along with overrides
-                const restore: Promise<string[]> = plugin.settings.trackOpenFiles
-                  ? plugin.utils.restoreOpenFiles(workspaceName, workspace).then(async restoredLeafIds => {
-                      const overriddenLeafIds = await plugin.utils.applyFileOverrides(workspaceName, workspace);
-                      return [...restoredLeafIds, ...overriddenLeafIds];
-                    })
+                // Restore tracked files, then overrides -- sequential (not Promise.all) is
+                // intentional: when the same leaf is both tracked and overridden, the override
+                // must win, which only holds if it's applied after restoreOpenFiles.
+                const restore: Promise<void> = plugin.settings.trackOpenFiles
+                  ? plugin.utils
+                      .restoreOpenFiles(workspaceName, workspace)
+                      .then(() => plugin.utils.applyFileOverrides(workspaceName, workspace))
                   : plugin.utils.applyFileOverrides(workspaceName, workspace);
                 restore
-                  .then(async loadedLeafIds => {
+                  .catch((e: unknown) => {
+                    // Swallow and continue to changeLayout() regardless -- both
+                    // restoreOpenFiles and applyFileOverrides already isolate per-leaf
+                    // errors internally, so a rejection here means something unexpected
+                    // happened, not "nothing was restored."
+                    console.error("failed to restore files:", e);
+                  })
+                  .then(async () => {
                     // A newer switch started while restore was running -- applying this
                     // (now-stale) layout would revert the user's screen back to it.
                     if (generation !== plugin.workspaceLoadGeneration) return;
                     await this.app.workspace.changeLayout(workspace);
-                    // changeLayout() creates the leaves but leaves in the background stay
-                    // "deferred" (a lightweight placeholder) until focused -- force-load the
-                    // ones we just set a file on so they render immediately instead of only
-                    // on click.
-                    for (const leafId of loadedLeafIds) {
-                      const leaf = this.app.workspace.getLeafById(leafId);
-                      if (leaf?.isDeferred) await leaf.loadIfDeferred();
-                    }
-                    // Check again: a newer switch could have started during changeLayout()
-                    // or the deferred-leaf loop above.
+                    if (generation !== plugin.workspaceLoadGeneration) return;
+                    // changeLayout() creates the leaves, but leaves in the background stay
+                    // "deferred" (a lightweight placeholder) until focused. Force-load every
+                    // deferred leaf in the workspace -- not just the ones this plugin wrote a
+                    // file into -- since any background leaf can be left in that state.
+                    const leaves: WorkspaceLeaf[] = [];
+                    this.app.workspace.iterateAllLeaves(leaf => leaves.push(leaf));
+                    await Promise.all(
+                      leaves.filter(leaf => leaf.isDeferred).map(leaf => leaf.loadIfDeferred())
+                    );
                     if (generation === plugin.workspaceLoadGeneration) this.saveData();
                   })
                   .catch((e: unknown) => {
-                    console.error("failed to restore files:", e);
-                    if (generation !== plugin.workspaceLoadGeneration) return;
-                    void this.app.workspace.changeLayout(workspace);
-                    this.saveData();
+                    console.error("failed to apply workspace layout:", e);
                   });
               }
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,11 @@ export default class WorkspacesPlus extends Plugin {
   // user-triggered call to enableModesFeature() (e.g. toggling modes on mid-session) still
   // does its own onWorkspaceLoad() call as before.
   private startupWorkspaceLoadTriggered = false;
+  // Incremented on every non-mode loadWorkspace() invocation. Lets an in-flight restore chain
+  // (restoreOpenFiles/applyFileOverrides -> changeLayout -> deferred-leaf loading -> saveData)
+  // recognize it's been superseded by a newer workspace switch and bail out instead of
+  // re-applying a stale layout or persisting stale data over the newer switch.
+  private workspaceLoadGeneration = 0;
 
   async onload() {
     this.debug = false;
@@ -585,6 +590,9 @@ export default class WorkspacesPlus extends Plugin {
               const workspace = this.workspaces[workspaceName];
               if (workspace) {
                 this.activeWorkspace = workspaceName;
+                // Guards against a rapid second switch superseding this one while its restore
+                // chain is still in flight (see the generation checks below).
+                const generation = ++plugin.workspaceLoadGeneration;
                 // Restore tracked files along with overrides
                 const restore: Promise<string[]> = plugin.settings.trackOpenFiles
                   ? plugin.utils.restoreOpenFiles(workspaceName, workspace).then(async restoredLeafIds => {
@@ -594,6 +602,9 @@ export default class WorkspacesPlus extends Plugin {
                   : plugin.utils.applyFileOverrides(workspaceName, workspace);
                 restore
                   .then(async loadedLeafIds => {
+                    // A newer switch started while restore was running -- applying this
+                    // (now-stale) layout would revert the user's screen back to it.
+                    if (generation !== plugin.workspaceLoadGeneration) return;
                     await this.app.workspace.changeLayout(workspace);
                     // changeLayout() creates the leaves but leaves in the background stay
                     // "deferred" (a lightweight placeholder) until focused -- force-load the
@@ -603,10 +614,13 @@ export default class WorkspacesPlus extends Plugin {
                       const leaf = this.app.workspace.getLeafById(leafId);
                       if (leaf?.isDeferred) await leaf.loadIfDeferred();
                     }
-                    this.saveData();
+                    // Check again: a newer switch could have started during changeLayout()
+                    // or the deferred-leaf loop above.
+                    if (generation === plugin.workspaceLoadGeneration) this.saveData();
                   })
                   .catch((e: unknown) => {
                     console.error("failed to restore files:", e);
+                    if (generation !== plugin.workspaceLoadGeneration) return;
                     void this.app.workspace.changeLayout(workspace);
                     this.saveData();
                   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,12 @@ export default class WorkspacesPlus extends Plugin {
   nativeWorkspaceRibbonItem: HTMLElement;
   isNativePluginEnabled: boolean;
   utils: Utils;
+  // Set when setPlatformWorkspace() triggers a workspace-load at startup, so
+  // enableModesFeature()'s own onWorkspaceLoad() bootstrap call can skip re-running it.
+  // One-shot: consumed (cleared) the first time enableModesFeature() checks it, so a later,
+  // user-triggered call to enableModesFeature() (e.g. toggling modes on mid-session) still
+  // does its own onWorkspaceLoad() call as before.
+  private startupWorkspaceLoadTriggered = false;
 
   async onload() {
     this.debug = false;
@@ -176,6 +182,7 @@ export default class WorkspacesPlus extends Plugin {
       // that label; without an actual reload, the status bar can end up naming a workspace whose
       // layout was never restored, disagreeing with whatever Obsidian's native session-restore
       // happened to reopen.
+      this.startupWorkspaceLoadTriggered = true;
       this.workspacePlugin.loadWorkspace(_activeWorkspace);
     }
   }
@@ -225,8 +232,14 @@ export default class WorkspacesPlus extends Plugin {
         name: "Open mode switcher",
         callback: () => new WorkspacesPlusPluginModeModal(this, this.settings, true).open(),
       });
-      if (this.debug) console.debug("toggle load", this.workspacePlugin.activeWorkspace);
-      this.onWorkspaceLoad(this.workspacePlugin.activeWorkspace);
+      if (this.startupWorkspaceLoadTriggered) {
+        // setPlatformWorkspace() already fired a workspace-load (and therefore
+        // onWorkspaceLoad) synchronously at startup -- avoid running it a second time.
+        this.startupWorkspaceLoadTriggered = false;
+      } else {
+        if (this.debug) console.debug("toggle load", this.workspacePlugin.activeWorkspace);
+        this.onWorkspaceLoad(this.workspacePlugin.activeWorkspace);
+      }
       this.registerEvent(this.app.vault.on("config-changed", this.onConfigChange));
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,9 +50,12 @@ export default class WorkspacesPlus extends Plugin {
     this.registerCommands();
 
     this.app.workspace.onLayoutReady(() => {
-      this.setPlatformWorkspace();
-      // store current Obsidian settings into local plugin storage
+      // store current Obsidian settings into local plugin storage -- must run before
+      // setPlatformWorkspace(), which can trigger a synchronous workspace-load that reads
+      // globalSettings back via mergeGlobalSettings(); if globalSettings were still empty at
+      // that point, applySettings() would overwrite (and persist) an empty app.vault.config.
       if (this.settings.workspaceSettings) this.storeGlobalSettings();
+      this.setPlatformWorkspace();
 
       this.backupCoreConfig();
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -276,7 +276,13 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
 
       new Setting(subContainerEL).setHeading().setName("File overrides");
 
-      getChildIds(workspace.main).forEach(leaf => {
+      // Leaves without an id can't be targeted by setChildId (it matches on split.id ===
+      // leafId), so an override entry keyed by a missing id could never actually apply --
+      // skip rendering a control for them rather than let several such leaves collide on
+      // the same fileOverrides[""] entry.
+      getChildIds(workspace.main)
+        .filter(leaf => leaf.id)
+        .forEach(leaf => {
         let currentFile: string;
         if (workspaceSettings.fileOverrides && workspaceSettings.fileOverrides[leaf.id]) {
           currentFile = workspaceSettings.fileOverrides[leaf.id];
@@ -284,7 +290,7 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
           currentFile = null;
         }
         new Setting(subContainerEL)
-          .setName(leaf.id ? leaf.id : "unknown")
+          .setName(leaf.id)
           .setClass("file-override")
           .addSearch(cb => {
             new FileSuggest(this.app, cb.inputEl);
@@ -438,14 +444,19 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
   }
 
   private buildWorkspacePage(workspaceName: string, workspace: Workspaces): SettingDefinitionPage {
-    const overrides: SettingGroupItem[] = getChildIds(workspace.main).map(leaf => ({
-      name: leaf.id ?? "unknown",
-      control: {
-        type: "file",
-        key: `workspace-override:${encodeURIComponent(workspaceName)}:${encodeURIComponent(leaf.id ?? "")}`,
-        placeholder: leaf.file ?? "",
-      },
-    }));
+    // See the matching comment in display() -- leaves without an id can't be targeted by
+    // setChildId, so they're skipped rather than rendered as controls that collide on the
+    // same key.
+    const overrides: SettingGroupItem[] = getChildIds(workspace.main)
+      .filter(leaf => leaf.id)
+      .map(leaf => ({
+        name: leaf.id,
+        control: {
+          type: "file",
+          key: `workspace-override:${encodeURIComponent(workspaceName)}:${encodeURIComponent(leaf.id)}`,
+          placeholder: leaf.file ?? "",
+        },
+      }));
 
     return {
       type: "page",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,6 +12,62 @@ import {
 } from "obsidian";
 import { FileSuggest } from "./suggesters/fileSuggest";
 
+interface ToggleText {
+  name?: string;
+  desc?: string;
+}
+
+// Shared name/desc text for the plugin's toggle settings, consumed by both display() (the
+// pre-1.13.0 fallback) and getSettingDefinitions() (the 1.13.0+ declarative UI) so the two
+// separately-structured implementations can't silently drift apart on wording. Keyed by the
+// WorkspacesPlusSettings property each toggle controls; "workspaceSettings" is the one
+// exception -- it only holds desc text here since display() renders its name with an extra
+// "beta" flair badge that has no equivalent in the declarative API's string-only name field.
+const TOGGLE_TEXT: Record<string, ToggleText> = {
+  showInstructions: {
+    name: "Show instructions",
+    desc: "Show available keyboard shortcuts at the bottom of the workspace quick switcher",
+  },
+  showDeletePrompt: {
+    name: "Show workspace delete confirmation",
+    desc: "Show a confirmation prompt on workspace deletion",
+  },
+  workspaceSwitcherRibbon: { name: "Show workspace sidebar ribbon icon" },
+  replaceNativeRibbon: { name: "Hide the native workspace sidebar ribbon icon" },
+  modeSwitcherRibbon: { name: "Show workspace mode sidebar ribbon icon" },
+  workspaceSettings: {
+    // name intentionally omitted -- display() renders its own name via createFragment (see
+    // below) to add the "beta" flair badge, and getSettingDefinitions() uses its own literal
+    // "Workspace modes (beta)" string since the declarative API's name field is string-only.
+    desc:
+      "Modes are a new type of workspace that store all of the native Obsidian editor, files & links, " +
+      "and appearance settings. Enabling this will add a new mode switcher to the status bar that will allow you " +
+      "to save, apply, rename, and switch between modes.",
+  },
+  saveOnChange: {
+    name: "Auto save the current workspace on layout change",
+    desc:
+      "This option will auto save your current workspace on any layout change. " +
+      "Leave this disabled if you want full control over when your workspace is saved.",
+  },
+  trackOpenFiles: {
+    name: "Automatically track and restore open files",
+    desc:
+      "When enabled, workspaces will remember which files were open and restore them when you switch back. " +
+      "This preserves your exact layout and open notes across workspace switches.",
+  },
+  systemDarkMode: {
+    name: "Respect system dark mode setting",
+    desc: "Let the os determine the light/dark mode setting when switching modes. This setting can only be used if workspace modes is enabled.",
+  },
+  reloadLivePreview: {
+    name: "Automatically reload Obsidian on live preview setting change",
+    desc:
+      "When switching between modes with different experimental live preview settings, reload Obsidian in order for the setting " +
+      "change to take effect. ⚠️note: Obsidian will reload automatically after changing workspaces, if needed, without any prompts.",
+  },
+};
+
 export class WorkspacesPlusSettings {
   showInstructions: boolean;
   showDeletePrompt: boolean;
@@ -83,8 +139,8 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
     }
     new Setting(containerEl).setName("Quick switcher").setHeading();
     new Setting(containerEl)
-      .setName("Show instructions")
-      .setDesc(`Show available keyboard shortcuts at the bottom of the workspace quick switcher`)
+      .setName(TOGGLE_TEXT.showInstructions.name)
+      .setDesc(TOGGLE_TEXT.showInstructions.desc)
       .addToggle(toggle =>
         toggle.setValue(this.plugin.settings.showInstructions).onChange(value => {
           this.plugin.settings.showInstructions = value;
@@ -93,8 +149,8 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      .setName("Show workspace delete confirmation")
-      .setDesc(`Show a confirmation prompt on workspace deletion`)
+      .setName(TOGGLE_TEXT.showDeletePrompt.name)
+      .setDesc(TOGGLE_TEXT.showDeletePrompt.desc)
       .addToggle(toggle =>
         toggle.setValue(this.plugin.settings.showDeletePrompt).onChange(value => {
           this.plugin.settings.showDeletePrompt = value;
@@ -103,8 +159,7 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      .setName("Show workspace sidebar ribbon icon")
-      // .setDesc(``)
+      .setName(TOGGLE_TEXT.workspaceSwitcherRibbon.name)
       .addToggle(toggle =>
         toggle.setValue(this.plugin.settings.workspaceSwitcherRibbon).onChange(value => {
           this.plugin.settings.workspaceSwitcherRibbon = value;
@@ -114,8 +169,7 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      .setName("Hide the native workspace sidebar ribbon icon")
-      // .setDesc(``)
+      .setName(TOGGLE_TEXT.replaceNativeRibbon.name)
       .addToggle(toggle =>
         toggle.setValue(this.plugin.settings.replaceNativeRibbon).onChange(value => {
           this.plugin.settings.replaceNativeRibbon = value;
@@ -125,8 +179,7 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      .setName("Show workspace mode sidebar ribbon icon")
-      // .setDesc(``)
+      .setName(TOGGLE_TEXT.modeSwitcherRibbon.name)
       .addToggle(toggle =>
         toggle.setValue(this.plugin.settings.modeSwitcherRibbon).onChange(value => {
           this.plugin.settings.modeSwitcherRibbon = value;
@@ -147,11 +200,7 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
           });
         })
       )
-      .setDesc(
-        `Modes are a new type of workspace that store all of the native Obsidian editor, files & links,
-        and appearance settings. Enabling this will add a new mode switcher to the status bar that will allow you
-        to save, apply, rename, and switch between modes.`
-      )
+      .setDesc(TOGGLE_TEXT.workspaceSettings.desc)
       .then(setting => {
         setting.settingEl.addClass("workspace-modes");
         if (this.plugin.settings.workspaceSettings) setting.settingEl.addClass("is-enabled");
@@ -169,11 +218,8 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
       });
 
     new Setting(containerEl)
-      .setName("Auto save the current workspace on layout change")
-      .setDesc(
-        `This option will auto save your current workspace on any layout change.
-         Leave this disabled if you want full control over when your workspace is saved.`
-      )
+      .setName(TOGGLE_TEXT.saveOnChange.name)
+      .setDesc(TOGGLE_TEXT.saveOnChange.desc)
       .addToggle(toggle =>
         toggle.setValue(this.plugin.settings.saveOnChange).onChange(value => {
           this.plugin.settings.saveOnChange = value;
@@ -182,11 +228,8 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      .setName("Automatically track and restore open files")
-      .setDesc(
-        `When enabled, workspaces will remember which files were open and restore them when you switch back. ` +
-        `This preserves your exact layout and open notes across workspace switches.`
-      )
+      .setName(TOGGLE_TEXT.trackOpenFiles.name)
+      .setDesc(TOGGLE_TEXT.trackOpenFiles.desc)
       .addToggle(toggle =>
         toggle.setValue(this.plugin.settings.trackOpenFiles).onChange(value => {
           this.plugin.settings.trackOpenFiles = value;
@@ -195,11 +238,9 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      .setName("Respect system dark mode setting")
+      .setName(TOGGLE_TEXT.systemDarkMode.name)
       .setClass("requires-workspace-modes")
-      .setDesc(
-        `Let the os determine the light/dark mode setting when switching modes. This setting can only be used if workspace modes is enabled.`
-      )
+      .setDesc(TOGGLE_TEXT.systemDarkMode.desc)
       .addToggle(toggle =>
         toggle.setValue(this.plugin.settings.systemDarkMode).onChange(value => {
           this.plugin.settings.systemDarkMode = value;
@@ -208,12 +249,9 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      .setName("Automatically reload Obsidian on live preview setting change")
+      .setName(TOGGLE_TEXT.reloadLivePreview.name)
       .setClass("requires-workspace-modes")
-      .setDesc(
-        `When switching between modes with different experimental live preview settings, reload Obsidian in order for the setting
-                change to take effect. ⚠️note: Obsidian will reload automatically after changing workspaces, if needed, without any prompts.`
-      )
+      .setDesc(TOGGLE_TEXT.reloadLivePreview.desc)
       .addToggle(toggle =>
         toggle.setValue(this.plugin.settings.reloadLivePreview).onChange(value => {
           this.plugin.settings.reloadLivePreview = value;
@@ -257,7 +295,7 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
       new Setting(subContainerEL).setName("Workspace description").addText(textfield => {
         textfield.inputEl.type = "text";
         textfield.inputEl.parentElement?.addClass("search-input-container");
-        textfield.setValue(String(workspaceSettings?.description || ""));
+        textfield.setValue(String(workspaceSettings?.description ?? ""));
         textfield.onChange(value => {
           workspaceSettings.description = value;
           this.plugin.workspacePlugin.saveData();
@@ -377,25 +415,25 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
         heading: "Quick switcher",
         items: [
           {
-            name: "Show instructions",
-            desc: "Show available keyboard shortcuts at the bottom of the workspace quick switcher",
+            name: TOGGLE_TEXT.showInstructions.name,
+            desc: TOGGLE_TEXT.showInstructions.desc,
             control: { type: "toggle", key: "showInstructions" },
           },
           {
-            name: "Show workspace delete confirmation",
-            desc: "Show a confirmation prompt on workspace deletion",
+            name: TOGGLE_TEXT.showDeletePrompt.name,
+            desc: TOGGLE_TEXT.showDeletePrompt.desc,
             control: { type: "toggle", key: "showDeletePrompt" },
           },
           {
-            name: "Show workspace sidebar ribbon icon",
+            name: TOGGLE_TEXT.workspaceSwitcherRibbon.name,
             control: { type: "toggle", key: "workspaceSwitcherRibbon" },
           },
           {
-            name: "Hide the native workspace sidebar ribbon icon",
+            name: TOGGLE_TEXT.replaceNativeRibbon.name,
             control: { type: "toggle", key: "replaceNativeRibbon" },
           },
           {
-            name: "Show workspace mode sidebar ribbon icon",
+            name: TOGGLE_TEXT.modeSwitcherRibbon.name,
             control: { type: "toggle", key: "modeSwitcherRibbon" },
           },
         ],
@@ -405,29 +443,31 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
         heading: "Workspace enhancements",
         items: [
           {
+            // "(beta)" appended here rather than shared -- display() renders the badge as a
+            // separate DOM span instead of plain text; see the comment on TOGGLE_TEXT above.
             name: "Workspace modes (beta)",
-            desc: "Modes are a new type of workspace that store all of the native Obsidian editor, files & links, and appearance settings. Enabling this will add a new mode switcher to the status bar that will allow you to save, apply, rename, and switch between modes.",
+            desc: TOGGLE_TEXT.workspaceSettings.desc,
             control: { type: "toggle", key: "workspaceSettings" },
           },
           {
-            name: "Auto save the current workspace on layout change",
-            desc: "This option will auto save your current workspace on any layout change. Leave this disabled if you want full control over when your workspace is saved.",
+            name: TOGGLE_TEXT.saveOnChange.name,
+            desc: TOGGLE_TEXT.saveOnChange.desc,
             control: { type: "toggle", key: "saveOnChange" },
           },
           {
-            name: "Automatically track and restore open files",
-            desc: "When enabled, workspaces will remember which files were open and restore them when you switch back. This preserves your exact layout and open notes across workspace switches.",
+            name: TOGGLE_TEXT.trackOpenFiles.name,
+            desc: TOGGLE_TEXT.trackOpenFiles.desc,
             control: { type: "toggle", key: "trackOpenFiles" },
           },
           {
-            name: "Respect system dark mode setting",
-            desc: "Let the os determine the light/dark mode setting when switching modes. This setting can only be used if workspace modes is enabled.",
+            name: TOGGLE_TEXT.systemDarkMode.name,
+            desc: TOGGLE_TEXT.systemDarkMode.desc,
             control: { type: "toggle", key: "systemDarkMode" },
             visible: () => this.plugin.settings.workspaceSettings,
           },
           {
-            name: "Automatically reload Obsidian on live preview setting change",
-            desc: "When switching between modes with different experimental live preview settings, reload Obsidian in order for the setting change to take effect. ⚠️note: Obsidian will reload automatically after changing workspaces, if needed, without any prompts.",
+            name: TOGGLE_TEXT.reloadLivePreview.name,
+            desc: TOGGLE_TEXT.reloadLivePreview.desc,
             control: { type: "toggle", key: "reloadLivePreview" },
             visible: () => this.plugin.settings.workspaceSettings,
           },

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,16 +1,11 @@
 import WorkspacesPlus from "./main";
-import {
-  App,
-  PluginSettingTab,
-  Setting,
-  setIcon,
-  WorkspaceLayoutNode,
-  Workspaces,
-  SettingDefinitionItem,
-  SettingGroupItem,
-  SettingDefinitionPage,
-} from "obsidian";
+import { App, PluginSettingTab, Setting, setIcon, WorkspaceLayoutNode, SettingDefinitionItem } from "obsidian";
 import { FileSuggest } from "./suggesters/fileSuggest";
+import {
+  getSettingDefinitions as declarativeGetSettingDefinitions,
+  getControlValue as declarativeGetControlValue,
+  setControlValue as declarativeSetControlValue,
+} from "./settingsDeclarative";
 
 interface ToggleText {
   name?: string;
@@ -23,7 +18,7 @@ interface ToggleText {
 // WorkspacesPlusSettings property each toggle controls; "workspaceSettings" is the one
 // exception -- it only holds desc text here since display() renders its name with an extra
 // "beta" flair badge that has no equivalent in the declarative API's string-only name field.
-const TOGGLE_TEXT: Record<string, ToggleText> = {
+export const TOGGLE_TEXT: Record<string, ToggleText> = {
   showInstructions: {
     name: "Show instructions",
     desc: "Show available keyboard shortcuts at the bottom of the workspace quick switcher",
@@ -108,7 +103,7 @@ interface ChildLeafSummary {
   mode?: unknown;
 }
 
-function getChildIds (split: WorkspaceLayoutNode, leafs: ChildLeafSummary[] = []): ChildLeafSummary[] {
+export function getChildIds (split: WorkspaceLayoutNode, leafs: ChildLeafSummary[] = []): ChildLeafSummary[] {
   if (split.type === "leaf") {
     leafs.push({ id: split.id, file: split.state?.state?.file, mode: split.state?.state?.mode });
   } else if (split.type === "split" || split.type === "tabs") {
@@ -390,213 +385,23 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
     });
   }
 
-  // Declarative settings API (Obsidian 1.13.0+). display() above remains the
-  // fallback for older versions (minAppVersion is 1.8.7) -- Obsidian only
-  // calls display() when this returns an empty array, which is what the
-  // inherited default does on versions that predate this API entirely.
-  // Keep the two in sync when editing either: same settings, same text,
-  // necessarily different structure (imperative DOM vs. declarative tree).
+  // Declarative settings API (Obsidian 1.13.0+). display() above remains the fallback for
+  // older versions (minAppVersion is 1.8.7) -- Obsidian only calls display() when
+  // getSettingDefinitions() returns an empty array, which is what the inherited default does
+  // on versions that predate this API entirely. The actual implementation lives in
+  // settingsDeclarative.ts (not here) so eslint.config.mjs's obsidianmd/no-unsupported-api
+  // override can be scoped to just that file instead of this whole one -- these three methods
+  // are the only things in this class that are 1.13.0+-only.
   getSettingDefinitions(): SettingDefinitionItem[] {
-    if (!this.plugin.utils.isNativePluginEnabled) {
-      return [{ name: "Please enable the workspaces plugin under core plugins before using this plugin" }];
-    }
-
-    const { workspaces } = this.plugin.workspacePlugin;
-    const workspacePages: SettingGroupItem[] = Object.keys(workspaces)
-      .filter(name => !this.plugin.utils.isMode(name))
-      .map(name => this.buildWorkspacePage(name, workspaces[name]));
-    const modePages: SettingGroupItem[] = Object.keys(workspaces)
-      .filter(name => this.plugin.utils.isMode(name))
-      .map(name => this.buildModePage(name));
-
-    return [
-      {
-        type: "group",
-        heading: "Quick switcher",
-        items: [
-          {
-            name: TOGGLE_TEXT.showInstructions.name,
-            desc: TOGGLE_TEXT.showInstructions.desc,
-            control: { type: "toggle", key: "showInstructions" },
-          },
-          {
-            name: TOGGLE_TEXT.showDeletePrompt.name,
-            desc: TOGGLE_TEXT.showDeletePrompt.desc,
-            control: { type: "toggle", key: "showDeletePrompt" },
-          },
-          {
-            name: TOGGLE_TEXT.workspaceSwitcherRibbon.name,
-            control: { type: "toggle", key: "workspaceSwitcherRibbon" },
-          },
-          {
-            name: TOGGLE_TEXT.replaceNativeRibbon.name,
-            control: { type: "toggle", key: "replaceNativeRibbon" },
-          },
-          {
-            name: TOGGLE_TEXT.modeSwitcherRibbon.name,
-            control: { type: "toggle", key: "modeSwitcherRibbon" },
-          },
-        ],
-      },
-      {
-        type: "group",
-        heading: "Workspace enhancements",
-        items: [
-          {
-            // "(beta)" appended here rather than shared -- display() renders the badge as a
-            // separate DOM span instead of plain text; see the comment on TOGGLE_TEXT above.
-            name: "Workspace modes (beta)",
-            desc: TOGGLE_TEXT.workspaceSettings.desc,
-            control: { type: "toggle", key: "workspaceSettings" },
-          },
-          {
-            name: TOGGLE_TEXT.saveOnChange.name,
-            desc: TOGGLE_TEXT.saveOnChange.desc,
-            control: { type: "toggle", key: "saveOnChange" },
-          },
-          {
-            name: TOGGLE_TEXT.trackOpenFiles.name,
-            desc: TOGGLE_TEXT.trackOpenFiles.desc,
-            control: { type: "toggle", key: "trackOpenFiles" },
-          },
-          {
-            name: TOGGLE_TEXT.systemDarkMode.name,
-            desc: TOGGLE_TEXT.systemDarkMode.desc,
-            control: { type: "toggle", key: "systemDarkMode" },
-            visible: () => this.plugin.settings.workspaceSettings,
-          },
-          {
-            name: TOGGLE_TEXT.reloadLivePreview.name,
-            desc: TOGGLE_TEXT.reloadLivePreview.desc,
-            control: { type: "toggle", key: "reloadLivePreview" },
-            visible: () => this.plugin.settings.workspaceSettings,
-          },
-        ],
-      },
-      { type: "group", heading: "Per workspace", items: workspacePages },
-      {
-        type: "group",
-        heading: "Per mode",
-        items: modePages,
-        visible: () => this.plugin.settings.workspaceSettings,
-      },
-    ];
-  }
-
-  private buildWorkspacePage(workspaceName: string, workspace: Workspaces): SettingDefinitionPage {
-    // See the matching comment in display() -- leaves without an id can't be targeted by
-    // setChildId, so they're skipped rather than rendered as controls that collide on the
-    // same key.
-    const overrides: SettingGroupItem[] = getChildIds(workspace.main)
-      .filter(leaf => leaf.id)
-      .map(leaf => ({
-        name: leaf.id,
-        control: {
-          type: "file",
-          key: `workspace-override:${encodeURIComponent(workspaceName)}:${encodeURIComponent(leaf.id)}`,
-          placeholder: leaf.file ?? "",
-        },
-      }));
-
-    return {
-      type: "page",
-      name: workspaceName,
-      items: [
-        {
-          name: "Workspace description",
-          control: { type: "text", key: `workspace-description:${encodeURIComponent(workspaceName)}` },
-        },
-        { type: "group", heading: "File overrides", items: overrides },
-      ],
-    };
-  }
-
-  private buildModePage(modeName: string): SettingDefinitionPage {
-    return {
-      type: "page",
-      name: modeName.replace(/^mode: /i, ""),
-      items: [
-        {
-          name: "Save and load left/right sidebar state",
-          control: { type: "toggle", key: `mode-save-sidebar:${encodeURIComponent(modeName)}` },
-        },
-      ],
-    };
+    return declarativeGetSettingDefinitions(this);
   }
 
   getControlValue(key: string): unknown {
-    if (key.startsWith("workspace-description:")) {
-      const workspaceName = decodeURIComponent(key.slice("workspace-description:".length));
-      return this.plugin.utils.getWorkspaceSettings(workspaceName)?.description ?? "";
-    }
-    if (key.startsWith("workspace-override:")) {
-      const { workspaceName, leafId } = this.parseOverrideKey(key);
-      return this.plugin.utils.getWorkspaceSettings(workspaceName)?.fileOverrides?.[leafId] ?? "";
-    }
-    if (key.startsWith("mode-save-sidebar:")) {
-      const modeName = decodeURIComponent(key.slice("mode-save-sidebar:".length));
-      return this.plugin.utils.getModeSettings(modeName)?.saveSidebar ?? false;
-    }
-    // invoked by Obsidian itself when getSettingDefinitions() is in play, i.e. on 1.13.0+; display() is the fallback
-    // for 1.8.7-1.12.x, where these methods are simply never called. See the comment above getSettingDefinitions().
-    return super.getControlValue(key);
+    return declarativeGetControlValue(this, key);
   }
 
   setControlValue(key: string, value: unknown): void {
-    if (key.startsWith("workspace-description:")) {
-      const workspaceName = decodeURIComponent(key.slice("workspace-description:".length));
-      const settings = this.plugin.utils.getWorkspaceSettings(workspaceName);
-      if (settings) settings.description = value as string;
-      this.plugin.workspacePlugin.saveData();
-      return;
-    }
-    if (key.startsWith("workspace-override:")) {
-      const { workspaceName, leafId } = this.parseOverrideKey(key);
-      const settings = this.plugin.utils.getWorkspaceSettings(workspaceName);
-      if (settings) {
-        if (!settings.fileOverrides) settings.fileOverrides = {};
-        const overrideFile = value as string;
-        if (overrideFile) settings.fileOverrides[leafId] = overrideFile;
-        else delete settings.fileOverrides[leafId];
-      }
-      this.plugin.workspacePlugin.saveData();
-      return;
-    }
-    if (key.startsWith("mode-save-sidebar:")) {
-      const modeName = decodeURIComponent(key.slice("mode-save-sidebar:".length));
-      const settings = this.plugin.utils.getModeSettings(modeName);
-      if (settings) settings.saveSidebar = value as boolean;
-      this.plugin.workspacePlugin.saveData();
-      return;
-    }
-
-    void super.setControlValue(key, value);
-
-    switch (key) {
-      case "workspaceSwitcherRibbon":
-        this.plugin.toggleWorkspaceRibbonButton();
-        break;
-      case "replaceNativeRibbon":
-        this.plugin.toggleNativeWorkspaceRibbon();
-        break;
-      case "modeSwitcherRibbon":
-        this.plugin.toggleModeRibbonButton();
-        break;
-      case "workspaceSettings":
-        if (value) this.plugin.enableModesFeature();
-        else this.plugin.disableModesFeature();
-        this.update();
-        break;
-    }
-  }
-
-  private parseOverrideKey(key: string): { workspaceName: string; leafId: string } {
-    const rest = key.slice("workspace-override:".length);
-    const sepIndex = rest.indexOf(":");
-    return {
-      workspaceName: decodeURIComponent(rest.slice(0, sepIndex)),
-      leafId: decodeURIComponent(rest.slice(sepIndex + 1)),
-    };
+    declarativeSetControlValue(this, key, value);
   }
 }
 

--- a/src/settingsDeclarative.ts
+++ b/src/settingsDeclarative.ts
@@ -1,0 +1,221 @@
+// Obsidian's declarative settings API (getSettingDefinitions/getControlValue/setControlValue),
+// used by WorkspacesPlusSettingsTab on Obsidian 1.13.0+ only -- display() in settings.ts remains
+// the fallback for 1.8.7-1.12.x. Split into its own file (rather than living directly on the
+// class in settings.ts) purely so eslint.config.mjs's obsidianmd/no-unsupported-api override can
+// be scoped to just these 1.13.0+-only methods, instead of the whole settings.ts file -- that
+// keeps the check active for display() and the rest of the settings tab.
+import { PluginSettingTab } from "obsidian";
+import type { SettingDefinitionItem, SettingGroupItem, SettingDefinitionPage, Workspaces } from "obsidian";
+import type { WorkspacesPlusSettingsTab } from "./settings";
+import { TOGGLE_TEXT, getChildIds } from "./settings";
+
+export function getSettingDefinitions(tab: WorkspacesPlusSettingsTab): SettingDefinitionItem[] {
+  if (!tab.plugin.utils.isNativePluginEnabled) {
+    return [{ name: "Please enable the workspaces plugin under core plugins before using this plugin" }];
+  }
+
+  const { workspaces } = tab.plugin.workspacePlugin;
+  const workspacePages: SettingGroupItem[] = Object.keys(workspaces)
+    .filter(name => !tab.plugin.utils.isMode(name))
+    .map(name => buildWorkspacePage(tab, name, workspaces[name]));
+  const modePages: SettingGroupItem[] = Object.keys(workspaces)
+    .filter(name => tab.plugin.utils.isMode(name))
+    .map(name => buildModePage(name));
+
+  return [
+    {
+      type: "group",
+      heading: "Quick switcher",
+      items: [
+        {
+          name: TOGGLE_TEXT.showInstructions.name,
+          desc: TOGGLE_TEXT.showInstructions.desc,
+          control: { type: "toggle", key: "showInstructions" },
+        },
+        {
+          name: TOGGLE_TEXT.showDeletePrompt.name,
+          desc: TOGGLE_TEXT.showDeletePrompt.desc,
+          control: { type: "toggle", key: "showDeletePrompt" },
+        },
+        {
+          name: TOGGLE_TEXT.workspaceSwitcherRibbon.name,
+          control: { type: "toggle", key: "workspaceSwitcherRibbon" },
+        },
+        {
+          name: TOGGLE_TEXT.replaceNativeRibbon.name,
+          control: { type: "toggle", key: "replaceNativeRibbon" },
+        },
+        {
+          name: TOGGLE_TEXT.modeSwitcherRibbon.name,
+          control: { type: "toggle", key: "modeSwitcherRibbon" },
+        },
+      ],
+    },
+    {
+      type: "group",
+      heading: "Workspace enhancements",
+      items: [
+        {
+          // "(beta)" appended here rather than shared -- display() renders the badge as a
+          // separate DOM span instead of plain text; see the comment on TOGGLE_TEXT in
+          // settings.ts.
+          name: "Workspace modes (beta)",
+          desc: TOGGLE_TEXT.workspaceSettings.desc,
+          control: { type: "toggle", key: "workspaceSettings" },
+        },
+        {
+          name: TOGGLE_TEXT.saveOnChange.name,
+          desc: TOGGLE_TEXT.saveOnChange.desc,
+          control: { type: "toggle", key: "saveOnChange" },
+        },
+        {
+          name: TOGGLE_TEXT.trackOpenFiles.name,
+          desc: TOGGLE_TEXT.trackOpenFiles.desc,
+          control: { type: "toggle", key: "trackOpenFiles" },
+        },
+        {
+          name: TOGGLE_TEXT.systemDarkMode.name,
+          desc: TOGGLE_TEXT.systemDarkMode.desc,
+          control: { type: "toggle", key: "systemDarkMode" },
+          visible: () => tab.plugin.settings.workspaceSettings,
+        },
+        {
+          name: TOGGLE_TEXT.reloadLivePreview.name,
+          desc: TOGGLE_TEXT.reloadLivePreview.desc,
+          control: { type: "toggle", key: "reloadLivePreview" },
+          visible: () => tab.plugin.settings.workspaceSettings,
+        },
+      ],
+    },
+    { type: "group", heading: "Per workspace", items: workspacePages },
+    {
+      type: "group",
+      heading: "Per mode",
+      items: modePages,
+      visible: () => tab.plugin.settings.workspaceSettings,
+    },
+  ];
+}
+
+function buildWorkspacePage(
+  tab: WorkspacesPlusSettingsTab,
+  workspaceName: string,
+  workspace: Workspaces
+): SettingDefinitionPage {
+  // See the matching comment in settings.ts's display() -- leaves without an id can't be
+  // targeted by setChildId, so they're skipped rather than rendered as controls that collide
+  // on the same key.
+  const overrides: SettingGroupItem[] = getChildIds(workspace.main)
+    .filter(leaf => leaf.id)
+    .map(leaf => ({
+      name: leaf.id,
+      control: {
+        type: "file",
+        key: `workspace-override:${encodeURIComponent(workspaceName)}:${encodeURIComponent(leaf.id)}`,
+        placeholder: leaf.file ?? "",
+      },
+    }));
+
+  return {
+    type: "page",
+    name: workspaceName,
+    items: [
+      {
+        name: "Workspace description",
+        control: { type: "text", key: `workspace-description:${encodeURIComponent(workspaceName)}` },
+      },
+      { type: "group", heading: "File overrides", items: overrides },
+    ],
+  };
+}
+
+function buildModePage(modeName: string): SettingDefinitionPage {
+  return {
+    type: "page",
+    name: modeName.replace(/^mode: /i, ""),
+    items: [
+      {
+        name: "Save and load left/right sidebar state",
+        control: { type: "toggle", key: `mode-save-sidebar:${encodeURIComponent(modeName)}` },
+      },
+    ],
+  };
+}
+
+function parseOverrideKey(key: string): { workspaceName: string; leafId: string } {
+  const rest = key.slice("workspace-override:".length);
+  const sepIndex = rest.indexOf(":");
+  return {
+    workspaceName: decodeURIComponent(rest.slice(0, sepIndex)),
+    leafId: decodeURIComponent(rest.slice(sepIndex + 1)),
+  };
+}
+
+export function getControlValue(tab: WorkspacesPlusSettingsTab, key: string): unknown {
+  if (key.startsWith("workspace-description:")) {
+    const workspaceName = decodeURIComponent(key.slice("workspace-description:".length));
+    return tab.plugin.utils.getWorkspaceSettings(workspaceName)?.description ?? "";
+  }
+  if (key.startsWith("workspace-override:")) {
+    const { workspaceName, leafId } = parseOverrideKey(key);
+    return tab.plugin.utils.getWorkspaceSettings(workspaceName)?.fileOverrides?.[leafId] ?? "";
+  }
+  if (key.startsWith("mode-save-sidebar:")) {
+    const modeName = decodeURIComponent(key.slice("mode-save-sidebar:".length));
+    return tab.plugin.utils.getModeSettings(modeName)?.saveSidebar ?? false;
+  }
+  // Only ever invoked by Obsidian itself when getSettingDefinitions() is in play, i.e. on
+  // 1.13.0+; display() is the fallback for 1.8.7-1.12.x, where these methods are simply never
+  // called. Calling PluginSettingTab's own default implementation directly (rather than via
+  // `super`, which is only usable from inside WorkspacesPlusSettingsTab's own class body in
+  // settings.ts) keeps this 1.13.0+-only reference contained to this file.
+  return PluginSettingTab.prototype.getControlValue.call(tab, key);
+}
+
+export function setControlValue(tab: WorkspacesPlusSettingsTab, key: string, value: unknown): void {
+  if (key.startsWith("workspace-description:")) {
+    const workspaceName = decodeURIComponent(key.slice("workspace-description:".length));
+    const settings = tab.plugin.utils.getWorkspaceSettings(workspaceName);
+    if (settings) settings.description = value as string;
+    tab.plugin.workspacePlugin.saveData();
+    return;
+  }
+  if (key.startsWith("workspace-override:")) {
+    const { workspaceName, leafId } = parseOverrideKey(key);
+    const settings = tab.plugin.utils.getWorkspaceSettings(workspaceName);
+    if (settings) {
+      if (!settings.fileOverrides) settings.fileOverrides = {};
+      const overrideFile = value as string;
+      if (overrideFile) settings.fileOverrides[leafId] = overrideFile;
+      else delete settings.fileOverrides[leafId];
+    }
+    tab.plugin.workspacePlugin.saveData();
+    return;
+  }
+  if (key.startsWith("mode-save-sidebar:")) {
+    const modeName = decodeURIComponent(key.slice("mode-save-sidebar:".length));
+    const settings = tab.plugin.utils.getModeSettings(modeName);
+    if (settings) settings.saveSidebar = value as boolean;
+    tab.plugin.workspacePlugin.saveData();
+    return;
+  }
+
+  void PluginSettingTab.prototype.setControlValue.call(tab, key, value);
+
+  switch (key) {
+    case "workspaceSwitcherRibbon":
+      tab.plugin.toggleWorkspaceRibbonButton();
+      break;
+    case "replaceNativeRibbon":
+      tab.plugin.toggleNativeWorkspaceRibbon();
+      break;
+    case "modeSwitcherRibbon":
+      tab.plugin.toggleModeRibbonButton();
+      break;
+    case "workspaceSettings":
+      if (value) tab.plugin.enableModesFeature();
+      else tab.plugin.disableModesFeature();
+      tab.update();
+      break;
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -188,35 +188,35 @@ export default class Utils {
     return result.find(filePath => filePath);
   }
 
-  // Returns the leaf IDs that got a real file applied, so the caller can force-load them past
-  // Obsidian's deferred-view optimization after changeLayout() -- otherwise a background leaf's
-  // overridden file doesn't actually render until the user clicks that tab.
-  async applyFileOverrides (workspaceName: string, workspace: Workspaces): Promise<string[]> {
+  async applyFileOverrides (workspaceName: string, workspace: Workspaces): Promise<void> {
     const workspaceSettings = this.getWorkspaceSettings(workspaceName);
     const fileOverrides = workspaceSettings?.fileOverrides;
-    const appliedLeafIds: string[] = [];
     if (fileOverrides) {
       await Promise.all(
         Object.entries(fileOverrides).map(async ([leafId, fileName]: [string, string]) => {
-          let parsedFileName = this.renderTemplateString(fileName);
+          // Each entry is isolated so one bad override (e.g. a periodic-note template that
+          // fails to resolve) can't abort the whole batch and lose overrides that would
+          // otherwise have applied fine.
+          try {
+            let parsedFileName = this.renderTemplateString(fileName);
 
-          await this.getPeriodicNoteFromPath(parsedFileName);
-          const abstractFile = this.app.vault.getAbstractFileByPath(normalizePath(parsedFileName));
-          const file = abstractFile instanceof TFile ? abstractFile : null;
-          if (!file) {
-            fileName = null;
-          }
-          const result = this.setChildId(workspace.main, leafId, file?.path);
-          if (!result) {
-            // clean up any overrides for panes that no longer exist
-            delete fileOverrides[leafId];
-          } else if (file) {
-            appliedLeafIds.push(leafId);
+            await this.getPeriodicNoteFromPath(parsedFileName);
+            const abstractFile = this.app.vault.getAbstractFileByPath(normalizePath(parsedFileName));
+            const file = abstractFile instanceof TFile ? abstractFile : null;
+            if (!file) {
+              fileName = null;
+            }
+            const result = this.setChildId(workspace.main, leafId, file?.path);
+            if (!result) {
+              // clean up any overrides for panes that no longer exist
+              delete fileOverrides[leafId];
+            }
+          } catch (e) {
+            console.error(`failed to apply file override for leaf ${leafId}:`, e);
           }
         })
       );
     }
-    return appliedLeafIds;
   }
 
   captureOpenFiles(workspace: Workspaces): { [key: string]: string } {
@@ -242,27 +242,26 @@ export default class Utils {
     return openFiles;
   }
 
-  // Returns the leaf IDs that got a real file restored -- see the comment on applyFileOverrides.
-  async restoreOpenFiles(workspaceName: string, workspace: Workspaces): Promise<string[]> {
+  async restoreOpenFiles(workspaceName: string, workspace: Workspaces): Promise<void> {
     const workspaceSettings = this.getWorkspaceSettings(workspaceName);
     const trackedFiles = workspaceSettings?.trackedFiles;
 
-    if (!trackedFiles) return [];
+    if (!trackedFiles) return;
 
-    const restoredLeafIds: string[] = [];
     for (const [leafId, filePath] of Object.entries(trackedFiles)) {
       const abstractFile = this.app.vault.getAbstractFileByPath(normalizePath(filePath));
       const file = abstractFile instanceof TFile ? abstractFile : null;
       if (file) {
         // FIle is found, set it
-        this.setChildId(workspace.main, leafId, file.path);
-        restoredLeafIds.push(leafId);
+        if (!this.setChildId(workspace.main, leafId, file.path)) {
+          // the leaf this file was tracked against no longer exists in the layout
+          delete trackedFiles[leafId];
+        }
       } else {
         // File not found, is not found, create a new one to keep layout intact
         this.setChildId(workspace.main, leafId, null);
       }
     }
-    return restoredLeafIds;
   }
 
   getModeSettings (name: string) {


### PR DESCRIPTION
## Summary
Fixes all 10 findings from a code review of #125, most severe first:

- **Critical**: `setPlatformWorkspace()`'s `loadWorkspace()` call could fire before `storeGlobalSettings()` seeded the settings baseline, causing `applySettings({})` to wipe and persist an empty `app.vault.config` on the first restart after enabling Workspace modes (if the user had already used regular workspace switching before).
- `onWorkspaceLoad` firing twice at startup (redundant settings-apply/reload work).
- File-override controls for leaves without a stable `id` collided onto the same storage key.
- A rapid second workspace switch could race a still-in-flight one and persist stale data (generation-token guard added).
- Consolidated fix: deferred-leaf force-loading is now general (every leaf `changeLayout()` left deferred, not just ones this plugin wrote a file into), which also resolved three smaller findings living in the same code (the error-path gap, a missing `setChildId` check, sequential-instead-of-parallel loading).
- Setting name/description text is now shared between `display()` and the declarative settings UI instead of hand-duplicated.
- The `no-unsupported-api` lint exemption is now scoped to a new `settingsDeclarative.ts` file instead of all of `settings.ts`.

## Test plan
- [x] `npm run build`, `npm run lint` (0 errors, 3 pre-existing accepted warnings), `npm test` all pass after every commit
- [ ] Live-test in Obsidian recommended before relying on this, especially the startup-sequencing and race-guard changes